### PR TITLE
move compileall.py to post-install like done for example in devel/cla…

### DIFF
--- a/devel/pnpm/Makefile
+++ b/devel/pnpm/Makefile
@@ -15,9 +15,9 @@ MODULES=	lang/python
 
 RUN_DEPENDS=	lang/node
 
-do-build:
-	${MODPY_BIN} ${MODPY_LIBDIR}/compileall.py \
-		${WRKDIR}/package/dist/node_modules/node-gyp/*
+NO_BUILD=	Yes
+
+WRKDIST=	${WRKDIR}/package
 
 do-install:
 	${INSTALL_DATA_DIR} ${PREFIX}/lib/node_modules/pnpm
@@ -25,5 +25,9 @@ do-install:
 	chown -R ${SHAREOWN}:${SHAREGRP} ${PREFIX}/lib/node_modules
 	ln -s ../lib/node_modules/pnpm/bin/pnpm.cjs ${PREFIX}/bin/pnpm
 	ln -s ../lib/node_modules/pnpm/bin/pnpx.cjs ${PREFIX}/bin/pnpx
+
+post-install:
+	${MODPY_BIN} ${MODPY_LIBDIR}/compileall.py \
+		${PREFIX}/lib/node_modules/pnpm/dist/node_modules/node-gyp/*
 
 .include <bsd.port.mk>


### PR DESCRIPTION
…ng-tools-extra. Set WRKDIST so that make update-patches doesn't error.